### PR TITLE
移除 React 严格模式

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -4,11 +4,6 @@ import './index.css'
 import App from './App'
 import * as serviceWorker from './serviceWorker'
 
-ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
-)
+ReactDOM.render(<App />, document.getElementById('root'))
 
 serviceWorker.register()


### PR DESCRIPTION
由于在严格模式下第三方库出现大量的错误，占据了浏览器控制台很多空间，给调试和开发带来了很大的麻烦。
既然暂时解决不了这些报错，那我暂时移除严格模式未尝不可。
fixes #5 