### PR TITLE
修复路由配置 Bug

### DIFF
--- a/app/src/routes/admin.js
+++ b/app/src/routes/admin.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Home from '../admin/pages/Home'
 import Feedback from '../admin/pages/Feedback'
 import Product from '../admin/pages/Product'
@@ -9,24 +8,24 @@ export default [
     // 主页
     path: '/admin',
     exact: true,
-    children: <Home />
+    component: Home
   },
   {
     // 反馈管理
     path: '/admin/manage/feedback',
     exact: false,
-    children: <Feedback />
+    component: Feedback
   },
   {
     // 产品管理
     path: '/admin/manage/product',
     exact: false,
-    children: <Product />
+    component: Product
   },
   {
     // 后台成员
     path: '/admin/role',
     exact: false,
-    children: <Role />
+    component: Role
   }
 ]

--- a/app/src/routes/user.js
+++ b/app/src/routes/user.js
@@ -1,4 +1,3 @@
-import React from 'react'
 import Home from '../user/pages/Home'
 import Profile from '../user/pages/Profile'
 import Feedback from '../user/pages/Feedback'
@@ -8,19 +7,18 @@ export default [
     // 主页
     path: '/',
     exact: true,
-    children: <Home />
+    component: Home
   },
   {
     // 个人中心
     path: '/profile',
     exact: false,
-    children: <Profile />
+    component: Profile
   },
   {
     // 反馈详情
     path: '/feedback/:id',
     exact: false,
-    /* eslint-disable react/display-name */
-    children: props => <Feedback {...props} />
+    component: Feedback
   }
 ]


### PR DESCRIPTION
https://github.com/anandzhang/issue-feedback-react/blob/a0c1091a45859467feb8f1a89adfdf6c46197f33/app/src/routes/user.js#L24

`react-router-dom` 的 `Route` 组件的 `children` 属性不应该使用在这里，而应该使用 `component`。
使用 `children` 函数返回一个组件导致每一个 `path` 下都进行了渲染。